### PR TITLE
Deploy OCR pipeline: Lambda functions + Step Functions rewrite

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -39,6 +39,7 @@ jobs:
           TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
 
   deploy-api:
+    needs: deploy-infra
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +77,21 @@ jobs:
           aws lambda update-function-code \
             --function-name expense-tracker-digest \
             --zip-file fileb://digest.zip
+
+      - name: Package Pipeline Lambdas
+        run: |
+          cd functions
+          pip install boto3 python-ulid python-dateutil -t package/
+          cp *.py package/
+          cd package && zip -r9 ../pipeline.zip . -q
+
+      - name: Deploy Pipeline Lambdas
+        run: |
+          for fn in receipt-validator ocr-processor categorizer expense-saver budget-checker notifier; do
+            aws lambda update-function-code \
+              --function-name expense-tracker-$fn \
+              --zip-file fileb://functions/pipeline.zip
+          done
 
   deploy-web:
     runs-on: ubuntu-latest

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -9,6 +9,16 @@ data "archive_file" "lambda_placeholder" {
   }
 }
 
+data "archive_file" "pipeline_placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/lambda-pipeline-placeholder.zip"
+
+  source {
+    content  = "# placeholder"
+    filename = "main.py"
+  }
+}
+
 data "archive_file" "digest_placeholder" {
   type        = "zip"
   output_path = "${path.module}/lambda-digest-placeholder.zip"
@@ -225,6 +235,113 @@ resource "aws_iam_role_policy" "lambda_digest_ses" {
         Effect   = "Allow"
         Action   = "ses:SendEmail"
         Resource = "*"
+      }
+    ]
+  })
+}
+
+# ── Receipt Pipeline Lambdas ──
+
+locals {
+  pipeline_functions = {
+    receipt-validator = { handler = "receipt_validator.handler", timeout = 30 }
+    ocr-processor     = { handler = "ocr_processor.handler", timeout = 60 }
+    categorizer       = { handler = "categorizer.handler", timeout = 10 }
+    expense-saver     = { handler = "expense_saver.handler", timeout = 30 }
+    budget-checker    = { handler = "budget_checker.handler", timeout = 30 }
+    notifier          = { handler = "notifier.handler", timeout = 30 }
+  }
+}
+
+resource "aws_lambda_function" "pipeline" {
+  for_each = local.pipeline_functions
+
+  function_name = "${var.project}-${each.key}"
+  role          = aws_iam_role.lambda_pipeline.arn
+  handler       = each.value.handler
+  runtime       = "python3.12"
+  timeout       = each.value.timeout
+  memory_size   = 128
+
+  filename         = data.archive_file.pipeline_placeholder.output_path
+  source_code_hash = data.archive_file.pipeline_placeholder.output_base64sha256
+
+  environment {
+    variables = {
+      DYNAMODB_TABLE         = aws_dynamodb_table.main.name
+      BUDGET_ALERT_TOPIC_ARN = aws_sns_topic.alerts.arn
+    }
+  }
+
+  tags = {
+    Project = var.project
+  }
+}
+
+# IAM Role for Pipeline Lambdas (shared)
+resource "aws_iam_role" "lambda_pipeline" {
+  name = "${var.project}-lambda-pipeline"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_pipeline_basic" {
+  role       = aws_iam_role.lambda_pipeline.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lambda_pipeline" {
+  name = "${var.project}-lambda-pipeline"
+  role = aws_iam_role.lambda_pipeline.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:HeadObject",
+        ]
+        Resource = "${aws_s3_bucket.receipts.arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "textract:AnalyzeExpense"
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:Query",
+        ]
+        Resource = [
+          aws_dynamodb_table.main.arn,
+          "${aws_dynamodb_table.main.arn}/index/*",
+        ]
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.alerts.arn
       }
     ]
   })

--- a/infra/stepfunctions.tf
+++ b/infra/stepfunctions.tf
@@ -1,46 +1,143 @@
-# Step Functions Express Workflow for receipt processing
+# Step Functions for receipt processing pipeline
 resource "aws_sfn_state_machine" "receipt_pipeline" {
   name     = "${var.project}-receipt-pipeline"
   role_arn = aws_iam_role.stepfunctions.arn
-  type     = "EXPRESS"
+  type     = "STANDARD"
 
   definition = jsonencode({
-    Comment = "Receipt processing pipeline"
-    StartAt = "AnalyzeReceipt"
+    Comment = "Receipt OCR pipeline: validate → OCR → categorize → save → budget check → notify"
+    StartAt = "ParseS3Key"
     States = {
-      AnalyzeReceipt = {
-        Type     = "Task"
-        Resource = "arn:aws:states:::aws-sdk:textract:analyzeExpense"
+      ParseS3Key = {
+        Type = "Pass"
         Parameters = {
-          "Document" = {
-            "S3Object" = {
-              "Bucket.$" = "$.bucket"
-              "Name.$"   = "$.key"
-            }
-          }
+          "bucket.$"     = "$.bucket"
+          "s3_key.$"     = "$.key"
+          "user_id.$"    = "States.ArrayGetItem(States.StringSplit($.key, '/'), 1)"
+          "receipt_id.$" = "States.ArrayGetItem(States.StringSplit($.key, '/'), 2)"
         }
-        Next = "SaveExpense"
+        Next = "ValidateReceipt"
+      }
+      ValidateReceipt = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          "FunctionName" = aws_lambda_function.pipeline["receipt-validator"].arn
+          "Payload.$"    = "$"
+        }
+        ResultPath  = "$"
+        ResultSelector = { "result.$" = "$.Payload" }
+        OutputPath  = "$.result"
+        Next        = "CheckValid"
+      }
+      CheckValid = {
+        Type = "Choice"
+        Choices = [
+          {
+            Variable     = "$.valid"
+            BooleanEquals = false
+            Next         = "MarkFailed"
+          }
+        ]
+        Default = "ProcessOCR"
+      }
+      ProcessOCR = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          "FunctionName" = aws_lambda_function.pipeline["ocr-processor"].arn
+          "Payload.$"    = "$"
+        }
+        ResultPath  = "$"
+        ResultSelector = { "result.$" = "$.Payload" }
+        OutputPath  = "$.result"
+        Next        = "CheckOCR"
+      }
+      CheckOCR = {
+        Type = "Choice"
+        Choices = [
+          {
+            Variable      = "$.ocr_success"
+            BooleanEquals = false
+            Next          = "MarkFailed"
+          }
+        ]
+        Default = "Categorize"
+      }
+      Categorize = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          "FunctionName" = aws_lambda_function.pipeline["categorizer"].arn
+          "Payload.$"    = "$"
+        }
+        ResultPath  = "$"
+        ResultSelector = { "result.$" = "$.Payload" }
+        OutputPath  = "$.result"
+        Next        = "SaveExpense"
       }
       SaveExpense = {
         Type     = "Task"
-        Resource = "arn:aws:states:::dynamodb:putItem"
+        Resource = "arn:aws:states:::lambda:invoke"
         Parameters = {
-          "TableName" = aws_dynamodb_table.main.name
-          "Item" = {
-            "pk" = { "S.$" = "$.userId" }
-            "sk" = { "S.$" = "$.expenseId" }
-          }
+          "FunctionName" = aws_lambda_function.pipeline["expense-saver"].arn
+          "Payload.$"    = "$"
         }
-        Next = "NotifyUser"
+        ResultPath  = "$"
+        ResultSelector = { "result.$" = "$.Payload" }
+        OutputPath  = "$.result"
+        Next        = "CheckBudget"
       }
-      NotifyUser = {
+      CheckBudget = {
         Type     = "Task"
-        Resource = "arn:aws:states:::sns:publish"
+        Resource = "arn:aws:states:::lambda:invoke"
         Parameters = {
-          "TopicArn" = aws_sns_topic.alerts.arn
-          "Message.$" = "$.message"
+          "FunctionName" = aws_lambda_function.pipeline["budget-checker"].arn
+          "Payload.$"    = "$"
+        }
+        ResultPath  = "$"
+        ResultSelector = { "result.$" = "$.Payload" }
+        OutputPath  = "$.result"
+        Next        = "CheckExceeded"
+      }
+      CheckExceeded = {
+        Type = "Choice"
+        Choices = [
+          {
+            Variable      = "$.budget_exceeded"
+            BooleanEquals = true
+            Next          = "Notify"
+          }
+        ]
+        Default = "Done"
+      }
+      Notify = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          "FunctionName" = aws_lambda_function.pipeline["notifier"].arn
+          "Payload.$"    = "$"
+        }
+        ResultPath = "$.notify_result"
+        End        = true
+      }
+      MarkFailed = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::dynamodb:updateItem"
+        Parameters = {
+          "TableName"  = aws_dynamodb_table.main.name
+          "Key" = {
+            "pk" = { "S.$" = "States.Format('USER#{}', $.user_id)" }
+            "sk" = { "S.$" = "States.Format('RCV#{}', $.receipt_id)" }
+          }
+          "UpdateExpression"          = "SET #s = :failed"
+          "ExpressionAttributeNames"  = { "#s" = "status" }
+          "ExpressionAttributeValues" = { ":failed" = { "S" = "failed" } }
         }
         End = true
+      }
+      Done = {
+        Type = "Succeed"
       }
     }
   })
@@ -80,34 +177,16 @@ resource "aws_iam_role_policy" "stepfunctions" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = [
-          "textract:AnalyzeExpense",
-        ]
-        Resource = "*"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = [for fn in aws_lambda_function.pipeline : fn.arn]
       },
       {
         Effect = "Allow"
         Action = [
-          "dynamodb:PutItem",
           "dynamodb:UpdateItem",
         ]
         Resource = aws_dynamodb_table.main.arn
-      },
-      {
-        Effect   = "Allow"
-        Action   = "sns:Publish"
-        Resource = aws_sns_topic.alerts.arn
-      },
-      {
-        Effect   = "Allow"
-        Action   = "lambda:InvokeFunction"
-        Resource = aws_lambda_function.api.arn
-      },
-      {
-        Effect = "Allow"
-        Action = "s3:GetObject"
-        Resource = "${aws_s3_bucket.receipts.arn}/*"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Add 6 pipeline Lambda functions to Terraform (`receipt-validator`, `ocr-processor`, `categorizer`, `expense-saver`, `budget-checker`, `notifier`)
- Rewrite Step Functions from broken direct SDK integration to proper Lambda invocation chain
- Parse `user_id`/`receipt_id` from S3 key (`uploads/{user_id}/{receipt_id}/{filename}`) via intrinsic functions
- Add `MarkFailed` state to update receipt status to "failed" on validation/OCR errors
- Add pipeline Lambda packaging and deploy steps to CD workflow
- Make `deploy-api` depend on `deploy-infra` (Lambda resources must exist before code deploy)

## Pipeline flow
```
S3 upload → EventBridge → Step Functions:
  ParseS3Key → ValidateReceipt → ProcessOCR → Categorize → SaveExpense → CheckBudget → Notify
                    ↓ (invalid)        ↓ (no amount)
                  MarkFailed         MarkFailed
```

## Test plan
- [x] API unit tests pass (57 passed)
- [x] Web build passes
- [ ] After merge + CD: upload receipt → OCR completes → expense saved → dashboard updated

Generated with [Claude Code](https://claude.com/claude-code)