### PR TITLE
Cross-region OCR: Textract Lambda in us-east-1 with S3 Replication

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -85,13 +85,20 @@ jobs:
           cp *.py package/
           cd package && zip -r9 ../pipeline.zip . -q
 
-      - name: Deploy Pipeline Lambdas
+      - name: Deploy Pipeline Lambdas (ap-northeast-1)
         run: |
-          for fn in receipt-validator ocr-processor categorizer expense-saver budget-checker notifier; do
+          for fn in receipt-validator categorizer expense-saver budget-checker notifier; do
             aws lambda update-function-code \
               --function-name expense-tracker-$fn \
               --zip-file fileb://functions/pipeline.zip
           done
+
+      - name: Deploy OCR Lambda (us-east-1)
+        run: |
+          aws lambda update-function-code \
+            --function-name expense-tracker-ocr-processor \
+            --zip-file fileb://functions/pipeline.zip \
+            --region us-east-1
 
   deploy-web:
     runs-on: ubuntu-latest

--- a/functions/ocr_processor.py
+++ b/functions/ocr_processor.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import re
 
 import boto3
 
-# Textract AnalyzeExpense is not available in ap-northeast-1, use us-east-1
-textract = boto3.client("textract", region_name="us-east-1")
-s3 = boto3.client("s3")
+# Lambda runs in us-east-1 alongside Textract — no cross-region needed
+textract = boto3.client("textract")
 
 
 def _extract_field(expense_fields: list[dict], field_type: str) -> str | None:
@@ -31,17 +31,15 @@ def _parse_amount(raw: str | None) -> int | None:
 
 
 def handler(event: dict, context: object) -> dict:  # noqa: ARG001
-    bucket = event["bucket"]
     s3_key = event["s3_key"]
     receipt_id = event["receipt_id"]
     user_id = event["user_id"]
 
-    # Download from S3 (ap-northeast-1) and send bytes to Textract (us-east-1)
-    obj = s3.get_object(Bucket=bucket, Key=s3_key)
-    image_bytes = obj["Body"].read()
+    # Use the us-east-1 replica bucket (S3Object reference, 10MB limit)
+    us_bucket = os.environ.get("RECEIPTS_BUCKET_US", event.get("bucket", ""))
 
     resp = textract.analyze_expense(
-        Document={"Bytes": image_bytes}
+        Document={"S3Object": {"Bucket": us_bucket, "Name": s3_key}}
     )
 
     store_name = None
@@ -65,7 +63,7 @@ def handler(event: dict, context: object) -> dict:  # noqa: ARG001
     return {
         "receipt_id": receipt_id,
         "user_id": user_id,
-        "bucket": bucket,
+        "bucket": event.get("bucket", ""),
         "s3_key": s3_key,
         "extracted": {
             "store_name": store_name or "",

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -243,9 +243,9 @@ resource "aws_iam_role_policy" "lambda_digest_ses" {
 # ── Receipt Pipeline Lambdas ──
 
 locals {
+  # Pipeline Lambdas deployed in ap-northeast-1 (ocr-processor is in us-east-1)
   pipeline_functions = {
     receipt-validator = { handler = "receipt_validator.handler", timeout = 30 }
-    ocr-processor     = { handler = "ocr_processor.handler", timeout = 60 }
     categorizer       = { handler = "categorizer.handler", timeout = 10 }
     expense-saver     = { handler = "expense_saver.handler", timeout = 30 }
     budget-checker    = { handler = "budget_checker.handler", timeout = 30 }
@@ -321,11 +321,6 @@ resource "aws_iam_role_policy" "lambda_pipeline" {
         Resource = "${aws_s3_bucket.receipts.arn}/*"
       },
       {
-        Effect   = "Allow"
-        Action   = "textract:AnalyzeExpense"
-        Resource = "*"
-      },
-      {
         Effect = "Allow"
         Action = [
           "dynamodb:GetItem",
@@ -342,6 +337,82 @@ resource "aws_iam_role_policy" "lambda_pipeline" {
         Effect   = "Allow"
         Action   = "sns:Publish"
         Resource = aws_sns_topic.alerts.arn
+      }
+    ]
+  })
+}
+
+# ── OCR Processor Lambda (us-east-1, alongside Textract) ──
+
+resource "aws_lambda_function" "ocr_processor" {
+  provider = aws.us_east_1
+
+  function_name = "${var.project}-ocr-processor"
+  role          = aws_iam_role.lambda_ocr.arn
+  handler       = "ocr_processor.handler"
+  runtime       = "python3.12"
+  timeout       = 60
+  memory_size   = 256
+
+  filename         = data.archive_file.pipeline_placeholder.output_path
+  source_code_hash = data.archive_file.pipeline_placeholder.output_base64sha256
+
+  environment {
+    variables = {
+      RECEIPTS_BUCKET_US = aws_s3_bucket.receipts_us.id
+    }
+  }
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role" "lambda_ocr" {
+  name = "${var.project}-lambda-ocr"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_ocr_basic" {
+  role       = aws_iam_role.lambda_ocr.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lambda_ocr" {
+  name = "${var.project}-lambda-ocr"
+  role = aws_iam_role.lambda_ocr.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:HeadObject",
+        ]
+        Resource = "${aws_s3_bucket.receipts_us.arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "textract:AnalyzeExpense"
+        Resource = "*"
       }
     ]
   })

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -59,6 +59,130 @@ resource "aws_s3_bucket_notification" "receipts" {
   eventbridge = true
 }
 
+# ── Versioning (required for S3 Replication) ──
+
+resource "aws_s3_bucket_versioning" "receipts" {
+  bucket = aws_s3_bucket.receipts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "receipts_us" {
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.receipts_us.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# ── us-east-1 Receipts bucket (for Textract AnalyzeExpense) ──
+
+resource "aws_s3_bucket" "receipts_us" {
+  provider = aws.us_east_1
+  bucket   = "${var.project}-receipts-us-${data.aws_caller_identity.current.account_id}"
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "receipts_us" {
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.receipts_us.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ── S3 Cross-Region Replication: ap-northeast-1 → us-east-1 ──
+
+resource "aws_iam_role" "s3_replication" {
+  name = "${var.project}-s3-replication"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "s3.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role_policy" "s3_replication" {
+  name = "${var.project}-s3-replication"
+  role = aws_iam_role.s3_replication.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetReplicationConfiguration",
+          "s3:ListBucket",
+        ]
+        Resource = aws_s3_bucket.receipts.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObjectVersionForReplication",
+          "s3:GetObjectVersionAcl",
+          "s3:GetObjectVersionTagging",
+        ]
+        Resource = "${aws_s3_bucket.receipts.arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ReplicateObject",
+          "s3:ReplicateDelete",
+          "s3:ReplicateTags",
+        ]
+        Resource = "${aws_s3_bucket.receipts_us.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_replication_configuration" "receipts" {
+  depends_on = [
+    aws_s3_bucket_versioning.receipts,
+    aws_s3_bucket_versioning.receipts_us,
+  ]
+
+  role   = aws_iam_role.s3_replication.arn
+  bucket = aws_s3_bucket.receipts.id
+
+  rule {
+    id     = "replicate-uploads"
+    status = "Enabled"
+
+    filter {
+      prefix = "uploads/"
+    }
+
+    destination {
+      bucket        = aws_s3_bucket.receipts_us.arn
+      storage_class = "STANDARD"
+    }
+  }
+}
+
 # Frontend bucket
 resource "aws_s3_bucket" "frontend" {
   bucket        = "${var.project}-frontend-${data.aws_caller_identity.current.account_id}"

--- a/infra/stepfunctions.tf
+++ b/infra/stepfunctions.tf
@@ -45,7 +45,7 @@ resource "aws_sfn_state_machine" "receipt_pipeline" {
         Type     = "Task"
         Resource = "arn:aws:states:::lambda:invoke"
         Parameters = {
-          "FunctionName" = aws_lambda_function.pipeline["ocr-processor"].arn
+          "FunctionName" = aws_lambda_function.ocr_processor.arn
           "Payload.$"    = "$"
         }
         ResultPath  = "$"
@@ -179,7 +179,10 @@ resource "aws_iam_role_policy" "stepfunctions" {
       {
         Effect   = "Allow"
         Action   = "lambda:InvokeFunction"
-        Resource = [for fn in aws_lambda_function.pipeline : fn.arn]
+        Resource = concat(
+          [for fn in aws_lambda_function.pipeline : fn.arn],
+          [aws_lambda_function.ocr_processor.arn]
+        )
       },
       {
         Effect = "Allow"


### PR DESCRIPTION
## Summary
Closes #12

Textract AnalyzeExpense is unavailable in ap-northeast-1. Previous fix (Bytes method) has 5MB limit.

**Architecture:**
```
Upload → S3 (Tokyo) → S3 Replication → S3 (us-east-1)
                                              ↓
Step Functions → ocr-processor Lambda (us-east-1) → Textract (S3Object, 10MB)
```

### Changes
- `infra/s3.tf`: us-east-1 replica bucket + versioning + S3 CRR for `uploads/`
- `infra/lambda.tf`: `ocr-processor` in us-east-1 with dedicated IAM
- `infra/stepfunctions.tf`: ProcessOCR → us-east-1 Lambda ARN
- `functions/ocr_processor.py`: S3Object (10MB) instead of Bytes (5MB)
- `cd.yaml`: Deploy OCR Lambda to us-east-1 separately

## Test plan
- [x] Unit tests pass (57 passed)
- [x] Web build passes
- [ ] After CD: upload receipt → S3 Replication → Textract OCR → expense saved

Generated with [Claude Code](https://claude.com/claude-code)