### PR TITLE
Fix S3 Replication: add delete_marker_replication block

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
       - "api/**"
       - "web/**"
       - "functions/**"
+      - "infra/**"
       - ".github/**"
   merge_group:
     branches: [main]

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -176,6 +176,10 @@ resource "aws_s3_bucket_replication_configuration" "receipts" {
       prefix = "uploads/"
     }
 
+    delete_marker_replication {
+      status = "Disabled"
+    }
+
     destination {
       bucket        = aws_s3_bucket.receipts_us.arn
       storage_class = "STANDARD"


### PR DESCRIPTION
CD deploy-infra failed with: DeleteMarkerReplication must be specified. Added the required block.