### PR TITLE
ci: PR で terraform plan を走らせる check を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,3 +118,20 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
           pnpm check
+
+  terraform-plan:
+    runs-on: ubuntu-latest
+    env:
+      TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - uses: tommykey-apps/.github/.github/actions/terraform-plan@v1
+        with:
+          working-directory: infra


### PR DESCRIPTION
## Summary

`tommykey-apps/.github` の `terraform-plan` composite action (v1) を receipto の CI に組み込む。

## Changes

- `.github/workflows/ci.yaml` に `terraform-plan` job を追加
  - `TF_VAR_alert_email` を既存 secret から
  - AWS 認証は既存 secrets を流用

## Test plan

- [ ] `terraform-plan` job が緑になる

Fixes #44