### PR TITLE
fix(docs): jekyll-relative-links を有効化して Pages の .md リンク 404 を解消

### DIFF
--- a/docs/db/_config.yml
+++ b/docs/db/_config.yml
@@ -2,3 +2,11 @@ title: Receipto DB Schema
 description: tbls 自動生成 + 手書き補足 (DynamoDB シングルテーブル設計)
 theme: jekyll-theme-cayman
 markdown: kramdown
+
+# .md リンクを Jekyll ビルド時に .html に自動変換 (GitHub UI 上でも .md として動くまま、Pages でも 200)
+plugins:
+  - jekyll-relative-links
+
+relative_links:
+  enabled: true
+  collections: true


### PR DESCRIPTION
## 問題
#48 で Pages 公開した \`docs/db/\` で、Markdown 内の \`.md\` リンクが Pages 上で 404:
- \`docs/db/index.md\` → \`[entities.md](entities.md)\` / \`[access-patterns.md](access-patterns.md)\`
- \`docs/db/schema/README.md\` (tbls 自動生成) → \`[expense-tracker](expense-tracker.md)\`

## 原因
Jekyll は \`.md\` → \`.html\` ビルドするが、リンク内の \`.md\` はそのまま残すため、Pages 上に \`.md\` が存在せず 404。

## 対処
\`docs/db/_config.yml\` に \`jekyll-relative-links\` プラグインを追加。GitHub Pages 標準プラグイン (whitelist 入り、gem 追加不要)。

\`\`\`yaml
plugins:
  - jekyll-relative-links

relative_links:
  enabled: true
  collections: true
\`\`\`

ビルド時に \`.md\` リンクを \`.html\` に自動変換。元の \`.md\` 表記は維持されるので GitHub UI でもリンクが効く。tbls 自動生成ファイルにも手を加える必要なし。

## 関連
- 元 PR: #48

Closes #49

## Test plan
- [ ] PR の CI 緑
- [ ] マージ後、\`docs.yaml\` (Deploy API Docs) 再実行で Pages 更新
- [ ] \`https://tommykey-apps.github.io/receipto/db/\` の entities/access-patterns リンクが 200
- [ ] \`https://tommykey-apps.github.io/receipto/db/schema/\` の expense-tracker リンクが 200